### PR TITLE
fixed a crash, compile error and a performance fix

### DIFF
--- a/include/g2o_MultiCol_sim3_expmap.h
+++ b/include/g2o_MultiCol_sim3_expmap.h
@@ -29,6 +29,8 @@
 
 #include <Eigen/StdVector>
 
+#include <unordered_map>
+
 #include "misc.h"
 #include "cam_model_omni.h"
 #include "cam_system_omni.h"

--- a/src/cMultiFrame.cpp
+++ b/src/cMultiFrame.cpp
@@ -21,7 +21,7 @@
 /*
 * MultiCol-SLAM is based on ORB-SLAM2 which was also released under GPLv3
 * For more information see <https://github.com/raulmur/ORB_SLAM2>
-* Raúl Mur-Artal <raulmur at unizar dot es> (University of Zaragoza)
+* Raï¿½l Mur-Artal <raulmur at unizar dot es> (University of Zaragoza)
 */
 
 #include "cMultiFrame.h"
@@ -155,24 +155,7 @@ namespace MultiColSLAM
 				static_cast<double>(mnMaxX[c] - mnMinX[c]);
 			mfGridElementHeightInv[c] = static_cast<double>(FRAME_GRID_ROWS) /
 				static_cast<double>(mnMaxY[c] - mnMinY[c]);
-			//Scale Levels Info
-			mnScaleLevels = mp_mdBRIEF_extractorOct[c]->GetLevels();
-			mfScaleFactor = mp_mdBRIEF_extractorOct[c]->GetScaleFactor();
 
-			mvScaleFactors.resize(mnScaleLevels);
-			mvLevelSigma2.resize(mnScaleLevels);
-			mvScaleFactors[0] = 1.0;
-			mvLevelSigma2[0] = 1.0;
-
-			for (int i = 1; i < mnScaleLevels; ++i)
-			{
-				mvScaleFactors[i] = mvScaleFactors[i - 1] * mfScaleFactor;
-				mvLevelSigma2[i] = mvScaleFactors[i] * mvScaleFactors[i];
-			}
-
-			mvInvLevelSigma2.resize(mvLevelSigma2.size());
-			for (int i = 0; i < mnScaleLevels; ++i)
-				mvInvLevelSigma2[i] = 1 / mvLevelSigma2[i];
 
 			// Assign Features to Grid Cells
 			mGrids[c] = std::vector<std::vector<std::vector<size_t> > >(FRAME_GRID_COLS);
@@ -205,6 +188,25 @@ namespace MultiColSLAM
 		mvpMapPoints = std::vector<cMapPoint*>(totalN, static_cast<cMapPoint*>(NULL));
 		// next id
 		mnId = nNextId++;
+
+					//Scale Levels Info
+		mnScaleLevels = mp_mdBRIEF_extractorOct[0]->GetLevels();
+		mfScaleFactor = mp_mdBRIEF_extractorOct[0]->GetScaleFactor();
+
+		mvScaleFactors.resize(mnScaleLevels);
+		mvLevelSigma2.resize(mnScaleLevels);
+		mvScaleFactors[0] = 1.0;
+		mvLevelSigma2[0] = 1.0;
+
+		for (int i = 1; i < mnScaleLevels; ++i)
+		{
+			mvScaleFactors[i] = mvScaleFactors[i - 1] * mfScaleFactor;
+			mvLevelSigma2[i] = mvScaleFactors[i] * mvScaleFactors[i];
+		}
+
+		mvInvLevelSigma2.resize(mvLevelSigma2.size());
+		for (int i = 0; i < mnScaleLevels; ++i)
+			mvInvLevelSigma2[i] = 1 / mvLevelSigma2[i];
 
 		this->masksLearned = extractor[0]->GetMasksLearned();
 		this->descDimension = extractor[0]->GetDescriptorSize();
@@ -307,7 +309,7 @@ namespace MultiColSLAM
 		{
 			for (int iy = nMinCellY; iy <= nMaxCellY; ++iy)
 			{
-				std::vector<size_t> vCell = mGrids[cam][ix][iy];
+				const std::vector<size_t>& vCell = mGrids[cam][ix][iy];
 				if (vCell.empty())
 					continue;
 

--- a/src/cMultiKeyFrame.cpp
+++ b/src/cMultiKeyFrame.cpp
@@ -718,10 +718,10 @@ namespace MultiColSLAM
 		nMaxCellY = std::min(mnGridRows[cam] - 1, nMaxCellY);
 		if (nMaxCellY < 0)
 			return vIndices;
-
+		
 		for (int ix = nMinCellX; ix <= nMaxCellX; ix++)
 		{
-			std::vector<std::vector<size_t>> vCell = mGrids[cam][ix];
+			const std::vector<std::vector<size_t>>& vCell = mGrids[cam][ix];
 			for (int iy = nMinCellY; iy <= nMaxCellY; iy++)
 			{
 				for (size_t j = 0, jend = vCell[iy].size(); j < jend; j++)


### PR DESCRIPTION
#15 fixed a crash. Some times crashes when calling resize. From what I understand the mnScaleLevels stuff is the same for all cameras and can be done after the loop, can be wrong here.

#1 compile error, I had the same issue and it adding `#include <unordered_map>` fixed it for me.

Ran gperftools and noticed this line in particular. std::vector has to make a full copy in this case (cv::Mat wouldn't). 
std::vector<size_t> vCell = mGrids[cam][ix][iy];